### PR TITLE
audit: APEX-468 Possible replay attack within TTL after reset + APEX-469 Sequential batch ordering

### DIFF
--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -68,16 +68,16 @@ contract NativeTokenPredicate is
         Deposits memory _deposits = abi.decode(_data, (Deposits));
 
         // _deposits.batchId can not go into past
-        if (_deposits.batchId <= lastBatchId) {
+        if (_deposits.batchId != lastBatchId + 1) {
             revert BatchAlreadyExecuted();
         }
+
+        lastBatchId++;
 
         if (_deposits.ttlExpired < block.number) {
             gateway.ttlEvent(_data);
             return;
         }
-
-        lastBatchId = _deposits.batchId;
 
         ReceiverDeposit[] memory _receivers = _deposits.receivers;
         uint256 _receiversLength = _receivers.length;


### PR DESCRIPTION
Component: NativeTokenPredicate.sol

Reference: [link](https://github.com/Ethernal-Tech/apex-evm-gateway/blob/a9b33d9fefe893954d217d2d731619e6cc724c4a/contracts/NativeTokenPredicate.sol#L55)

Category: Critical



When resetting the counter to 0 an old message with unexpired TTL can be replayed.

Q:  Why not i -> i+1?


Component: NativeTokenPredicate.sol

Reference: [link](https://github.com/Ethernal-Tech/apex-evm-gateway/blob/a9b33d9fefe893954d217d2d731619e6cc724c4a/contracts/NativeTokenPredicate.sol#L71)

Category: Problematic code



The batches are handled in sequential way but are not required to be i -> i+1 sequential. This could open a vector for attacks.