### PR TITLE
audit: APEX-473 + APEX-474 Gateway contract emit events

### DIFF
--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -53,7 +53,12 @@ contract Gateway is
 
         if (!valid) revert InvalidSignature();
 
-        nativeTokenPredicate.deposit(_data, msg.sender);
+        bool success = nativeTokenPredicate.deposit(_data, msg.sender);
+        if (success) {
+            emit Deposit(_data);
+        } else {
+            emit TTLExpired(_data);
+        }
     }
 
     function withdraw(
@@ -104,14 +109,6 @@ contract Gateway is
         if (!valid) revert InvalidSignature();
 
         validators.updateValidatorsChainData(_data);
-    }
-
-    function depositEvent(bytes calldata _data) external onlyPredicate {
-        emit Deposit(_data);
-    }
-
-    function ttlEvent(bytes calldata _data) external onlyPredicate {
-        emit TTLExpired(_data);
     }
 
     receive() external payable {

--- a/contracts/interfaces/IGateway.sol
+++ b/contracts/interfaces/IGateway.sol
@@ -15,8 +15,4 @@ interface IGateway is IGatewayStructs {
         ReceiverWithdraw[] calldata _receivers,
         uint256 _feeAmount
     ) external payable;
-
-    function depositEvent(bytes calldata data) external;
-
-    function ttlEvent(bytes calldata data) external;
 }

--- a/contracts/interfaces/INativeTokenPredicate.sol
+++ b/contracts/interfaces/INativeTokenPredicate.sol
@@ -4,5 +4,8 @@ pragma solidity ^0.8.24;
 import "./IGatewayStructs.sol";
 
 interface INativeTokenPredicate is IGatewayStructs {
-    function deposit(bytes calldata data, address relayer) external;
+    function deposit(
+        bytes calldata data,
+        address relayer
+    ) external returns (bool);
 }

--- a/test/NativeTokenPredicate.test.ts
+++ b/test/NativeTokenPredicate.test.ts
@@ -45,28 +45,6 @@ describe("NativeTokenPredicate Contract", function () {
     );
   });
 
-  it("Deposit should emit TTLExpired if TTL expired", async () => {
-    const { gateway, nativeTokenPredicate } = await loadFixture(deployGatewayFixtures);
-
-    const blockNumber = await ethers.provider.getBlockNumber();
-    const abiCoder = new ethers.AbiCoder();
-    const address = ethers.Wallet.createRandom().address;
-    const dataTTLExpired = abiCoder.encode(
-      ["tuple(uint64, uint64, uint256, tuple(uint8, address, uint256)[])"],
-      [[1, blockNumber - 1, 1, [[1, address, 100]]]]
-    );
-
-    const gatewayContract = await impersonateAsContractAndMintFunds(await gateway.getAddress());
-
-    const ttlTx = await nativeTokenPredicate.connect(gatewayContract).deposit(dataTTLExpired, address);
-    const ttlReceipt = await ttlTx.wait();
-    const ttlEvent = ttlReceipt.logs.find((log) => log.fragment.name === "TTLExpired");
-    const depositEvent = ttlReceipt.logs.find((log) => log.fragment.name === "Deposit");
-
-    expect(ttlEvent?.args?.data).to.equal(dataTTLExpired);
-    expect(depositEvent?.args?.data).to.be.undefined;
-  });
-
   it("Deposit should fail if batch is already executed", async () => {
     const { gateway, nativeTokenPredicate, data } = await loadFixture(deployGatewayFixtures);
 
@@ -80,19 +58,5 @@ describe("NativeTokenPredicate Contract", function () {
       nativeTokenPredicate,
       "BatchAlreadyExecuted"
     );
-  });
-
-  it("Deposit success", async () => {
-    const { gateway, nativeTokenPredicate, data } = await loadFixture(deployGatewayFixtures);
-
-    const address = ethers.Wallet.createRandom().address;
-
-    const gatewayContract = await impersonateAsContractAndMintFunds(await gateway.target);
-
-    const depositTx = await nativeTokenPredicate.connect(gatewayContract).deposit(data, address);
-    const depositReceipt = await depositTx.wait();
-    const depositEvent = depositReceipt.logs.find((log) => log.fragment && log.fragment.name === "Deposit");
-
-    expect(depositEvent?.args?.data).to.equal(data);
   });
 });


### PR DESCRIPTION
Component: Gateway.sol

Reference: [link](https://github.com/Ethernal-Tech/apex-evm-gateway/blob/a9b33d9fefe893954d217d2d731619e6cc724c4a/contracts/Gateway.sol#L109)

Category: Performance



Gateway contract can wait for the predicate to finish the execution and emit the `depositEvent` event by itself.

Component: Gateway.sol

Reference: [link](https://github.com/Ethernal-Tech/apex-evm-gateway/blob/a9b33d9fefe893954d217d2d731619e6cc724c4a/contracts/Gateway.sol#L113)

Category: Performance



Same as for `depositEvent`. The Gateway contract can wait for the predicate to finish the execution and emit the event by itself.