### PR TITLE
audit: APEX-478 Import syntax

### DIFF
--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "./interfaces/IGateway.sol";
-import "./interfaces/IGatewayStructs.sol";
-import "./interfaces/IValidators.sol";
-import "./NativeTokenPredicate.sol";
+import {IGateway} from "./interfaces/IGateway.sol";
+import {IGatewayStructs} from "./interfaces/IGatewayStructs.sol";
+import {IValidators} from "./interfaces/IValidators.sol";
+import {NativeTokenPredicate} from "./NativeTokenPredicate.sol";
 
 contract Gateway is
     IGateway,

--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -8,10 +8,10 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
-import "./interfaces/INativeTokenPredicate.sol";
-import "./interfaces/INativeTokenWallet.sol";
-import "./interfaces/IGateway.sol";
-import "./interfaces/IGatewayStructs.sol";
+import {INativeTokenPredicate} from "./interfaces/INativeTokenPredicate.sol";
+import {INativeTokenWallet} from "./interfaces/INativeTokenWallet.sol";
+import {IGateway} from "./interfaces/IGateway.sol";
+import {IGatewayStructs} from "./interfaces/IGatewayStructs.sol";
 
 /**
     @title ERC20TokenPredicate

--- a/contracts/NativeTokenWallet.sol
+++ b/contracts/NativeTokenWallet.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "./interfaces/IGatewayStructs.sol";
-import "./interfaces/INativeTokenWallet.sol";
-import "./NativeTokenPredicate.sol";
+import {IGatewayStructs} from "./interfaces/IGatewayStructs.sol";
+import {INativeTokenWallet} from "./interfaces/INativeTokenWallet.sol";
+import {NativeTokenPredicate} from "./NativeTokenPredicate.sol";
 
 /**
     @title NativeToken

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -5,8 +5,8 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "./interfaces/IValidators.sol";
-import "./interfaces/IGatewayStructs.sol";
+import {IValidators} from "./interfaces/IValidators.sol";
+import {IGatewayStructs} from "./interfaces/IGatewayStructs.sol";
 
 contract Validators is
     IValidators,

--- a/contracts/interfaces/IGateway.sol
+++ b/contracts/interfaces/IGateway.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./IGatewayStructs.sol";
+import {IGatewayStructs} from "./IGatewayStructs.sol";
 
 interface IGateway is IGatewayStructs {
     function deposit(

--- a/contracts/interfaces/INativeTokenPredicate.sol
+++ b/contracts/interfaces/INativeTokenPredicate.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./IGatewayStructs.sol";
+import {IGatewayStructs} from "./IGatewayStructs.sol";
 
 interface INativeTokenPredicate is IGatewayStructs {
     function deposit(

--- a/contracts/interfaces/IValidators.sol
+++ b/contracts/interfaces/IValidators.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import "./IGatewayStructs.sol";
+import {IGatewayStructs} from "./IGatewayStructs.sol";
 
 interface IValidators is IGatewayStructs {
     function setValidatorsChainData(


### PR DESCRIPTION
Reference: [link](https://github.com/Ethernal-Tech/apex-evm-gateway/blob/a9b33d9fefe893954d217d2d731619e6cc724c4a/contracts/interfaces/INativeTokenPredicate.sol#L4)

Category: Code Style

Should use import { X } from “../X.sol”; instead of: import “X.sol” - multiple files could provide other imports this way