### PR TITLE
Bug Fixes for NativeTokenPredicate

### DIFF
--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -31,9 +31,6 @@ contract NativeTokenPredicate is
     address public gateway;
     INativeTokenWallet public nativeTokenWallet;
 
-    // This field was used in the first version and is retained due to proxy pattern storage layout restrictions.
-    mapping(uint64 => bool) public unused1;
-
     /// @notice Tracks the ID of the last processed batch.
     uint64 public lastBatchId;
 

--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -83,7 +83,7 @@ contract NativeTokenPredicate is
             revert BatchAlreadyExecuted();
         }
 
-        lastBatchId++;
+        lastBatchId = _deposits.batchId;
 
         if (_deposits.ttlExpired < block.number) {
             return false;

--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -31,6 +31,9 @@ contract NativeTokenPredicate is
     address public gateway;
     INativeTokenWallet public nativeTokenWallet;
 
+    // This field was used in the first version and is retained due to proxy pattern storage layout restrictions.
+    mapping(uint64 => bool) public unused1;
+
     /// @notice Tracks the ID of the last processed batch.
     uint64 public lastBatchId;
 

--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -30,8 +30,6 @@ contract NativeTokenPredicate is
 
     address public gateway;
     INativeTokenWallet public nativeTokenWallet;
-    mapping(uint64 => bool) public unused1; // remove it before deploying to production
-    uint64 public unused2; // remove it before deploying to production
 
     /// @notice Tracks the ID of the last processed batch.
     uint64 public lastBatchId;

--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -77,8 +77,8 @@ contract NativeTokenPredicate is
     ) external onlyGateway nonReentrant returns (bool) {
         Deposits memory _deposits = abi.decode(_data, (Deposits));
 
-        // _deposits.batchId can not go into past but can go into future
-        // this is not a bug, this is a mandatory by design and how oracles work
+        // _deposits.batchId cannot go into the past but can go into the future.
+        // This is not a bug; it is mandatory by design and aligns with how oracles work.
         if (_deposits.batchId <= lastBatchId) {
             revert BatchAlreadyExecuted();
         }

--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -92,6 +92,9 @@ contract NativeTokenPredicate is
         ReceiverDeposit[] memory _receivers = _deposits.receivers;
         uint256 _receiversLength = _receivers.length;
 
+        // If any nativeTokenWallet.deposit call fails, the entire execution must revert.
+        // This is mandatory because all deposits (_receiversLength + fee)
+        // must be executed as an atomic operation.
         for (uint256 i; i < _receiversLength; i++) {
             nativeTokenWallet.deposit(
                 _receivers[i].receiver,

--- a/contracts/NativeTokenPredicate.sol
+++ b/contracts/NativeTokenPredicate.sol
@@ -77,8 +77,9 @@ contract NativeTokenPredicate is
     ) external onlyGateway nonReentrant returns (bool) {
         Deposits memory _deposits = abi.decode(_data, (Deposits));
 
-        // _deposits.batchId can not go into past
-        if (_deposits.batchId != lastBatchId + 1) {
+        // _deposits.batchId can not go into past but can go into future
+        // this is not a bug, this is a mandatory by design and how oracles work
+        if (_deposits.batchId <= lastBatchId) {
             revert BatchAlreadyExecuted();
         }
 

--- a/contracts/NativeTokenWallet.sol
+++ b/contracts/NativeTokenWallet.sol
@@ -45,20 +45,17 @@ contract NativeTokenWallet is
      * @notice Deposits an amount of native tokens to a specific account.
      * @param _account The address of the account to deposit tokens to.
      * @param _amount The amount of tokens to deposit.
-     * @return success A boolean indicating whether the deposit was successful.
      * @dev Can only be called by the predicate contract or the contract owner.
      * Reverts if the transfer fails.
      */
     function deposit(
         address _account,
         uint256 _amount
-    ) external onlyPredicateOrOwner returns (bool) {
+    ) external onlyPredicateOrOwner {
         (bool success, ) = _account.call{value: _amount}("");
 
         // Revert the transaction if the transfer fails
         if (!success) revert TransferFailed();
-
-        return true;
     }
 
     receive() external payable {}

--- a/contracts/interfaces/INativeTokenWallet.sol
+++ b/contracts/interfaces/INativeTokenWallet.sol
@@ -14,7 +14,6 @@ interface INativeTokenWallet {
      * @dev Can only be called by the predicate or owner address
      * @param account Account of the user to mint the tokens to
      * @param amount Amount of tokens to mint to the account
-     * @return bool Returns true if function call is successful
      */
-    function deposit(address account, uint256 amount) external returns (bool);
+    function deposit(address account, uint256 amount) external;
 }

--- a/contracts/interfaces/INativeTokenWallet.sol
+++ b/contracts/interfaces/INativeTokenWallet.sol
@@ -14,6 +14,7 @@ interface INativeTokenWallet {
      * @dev Can only be called by the predicate or owner address
      * @param account Account of the user to mint the tokens to
      * @param amount Amount of tokens to mint to the account
+     * Reverts if the transfer fails.
      */
     function deposit(address account, uint256 amount) external;
 }


### PR DESCRIPTION
This fix reverts change from audit and also change slightly deposit function and adds comments

function `deposit( bytes calldata _data, address _relayer)` through `_data` parameter receives Deposits that contain an array of `ReceiverDeposit`. For each `ReceiverDeposit` a call will be made to `NativeTokenWallet`'s deposit function and in case any of these transfers fail the whole call will be reverted, thus not storing the `batchId` of this batch as `lastBatchId`.
In the next batch that is sent from the bridge, the next value of `batchId` will be sent and it will not be equal to `lastBatchId + 1`.
So, by design, the requirement is `batchId > lastBatchId`.